### PR TITLE
ci: adding codecov in unittests reusable workflow

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -37,3 +37,7 @@ jobs:
     - name: execute unit-test
       run: |
         tox -e unittests
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
enables usage of codecov in python packages.
This requires python packages that uses this workflow to:
- have unit tests
- use the pytest-cov for unit testing (see codecov manual)