### PR TITLE
codeowner: adding CI team as owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Ledger SAS
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# only CI team members are allowed to acknowledge PR
+*       @outpost-os/outpost-ci-team
+


### PR DESCRIPTION
A team dedicated to CI and worflows management has been created in order to get back ownership of all CI-related components of the orga